### PR TITLE
feat(ui): add icon to button using material-icons-extended and improve visual design

### DIFF
--- a/Clase1/app/build.gradle.kts
+++ b/Clase1/app/build.gradle.kts
@@ -37,10 +37,12 @@ android {
     buildFeatures {
         compose = true
     }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.15" // Asegúrate de que esta versión sea compatible con tu versión de Kotlin
+    }
 }
 
 dependencies {
-
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
@@ -49,8 +51,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-
     implementation(libs.androidx.ui.text)
+    implementation(libs.material.icons.extended) // Uso del catálogo de versiones para material-icons-extended
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/Clase1/app/src/main/java/com/example/clase1/MainActivity.kt
+++ b/Clase1/app/src/main/java/com/example/clase1/MainActivity.kt
@@ -5,22 +5,21 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Print
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.foundation.text.KeyboardOptions
-
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.text.KeyboardOptions
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,15 +43,23 @@ fun Example() {
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Spacer(modifier = Modifier.height(40.dp))
+        // Título
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = "Ejercicio 1",
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color(0xFF6200EE), // Violeta Material
+            modifier = Modifier.padding(bottom = 24.dp)
+        )
 
+        // Campo de texto y botón
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
             OutlinedTextField(
                 value = entryText,
                 onValueChange = { newText ->
-                    // Solo permitir caracteres numéricos
                     if (newText.all { it.isDigit() }) {
                         entryText = newText
                     }
@@ -64,29 +71,32 @@ fun Example() {
 
             Spacer(modifier = Modifier.width(8.dp))
 
-            Text(
-                text = nameButton,
-                color = Color.Magenta,
-                fontWeight = FontWeight.Bold,
-                fontSize = 20.sp,
+            Button(
+                onClick = { resultText = entryText },
                 modifier = Modifier
-                    .clickable {
-                        resultText = entryText
-                    }
-                    .padding(8.dp)
-            )
+                    .height(56.dp)
+                    .align(Alignment.CenterVertically)
+            ) {
+                Icon(Icons.Filled.Print, contentDescription = "Imprimir")
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = nameButton,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(40.dp))
 
-        // Caja decorativa para mostrar el resultado
+        // Resultado
         if (resultText.isNotEmpty()) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 8.dp)
                     .clip(RoundedCornerShape(12.dp))
-                    .background(Color(0xFFE0E0E0)) // gris claro
+                    .background(Color(0xFFE0E0E0))
                     .padding(16.dp)
             ) {
                 Text(

--- a/Clase1/gradle/libs.versions.toml
+++ b/Clase1/gradle/libs.versions.toml
@@ -25,10 +25,9 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-ui-text = { group = "androidx.compose.ui", name = "ui-text" }
-
+material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version = "1.7.8" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-


### PR DESCRIPTION
### Summary

This pull request introduces visual improvements to the main UI and adds an icon to the action button using `material-icons-extended`.

### Changes

- Set `kotlinCompilerExtensionVersion` in `composeOptions`
- Added `material-icons-extended` to the dependencies file
- Enhanced UI:
  - Added a prominent title
  - Styled the button with an icon and proper layout
