### PR TITLE
chore: add GitHub issue templates for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+name: Bug Report
+description: Report an unexpected behavior or issue
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: textarea
+    attributes:
+      label: Summary
+      description: Briefly describe the bug
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Open the app
+        2. Click on 'X'
+        3. See the error
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Screenshots or logs
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Other question or discussion
+    url: https://github.com/LucasOscarSimon/ejercicios-semana-1-ui/discussions
+    about: Use GitHub Discussions for general topics

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+name: Feature Request
+description: Suggest a new idea or improvement
+title: "[Feature]: "
+labels: [enhancement]
+body:
+  - type: textarea
+    attributes:
+      label: Summary
+      description: What's the feature or improvement about?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Why is this feature useful or necessary?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Suggested implementation
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+    validations:
+      required: false


### PR DESCRIPTION
### Summary

Adds predefined GitHub Issue Templates to improve consistency when reporting bugs and requesting new features.

### Changes

- Added `.github/ISSUE_TEMPLATE/bug_report.md` with structure for reproducing bugs
- Added `.github/ISSUE_TEMPLATE/feature_request.md` to suggest improvements
- Added `config.yml` to enable the GitHub Issue template picker

### Screenshots (optional)

_No UI changes were made._

### Notes

You can now select between Bug Report or Feature Request when creating an issue.  
General questions can be redirected to GitHub Discussions (optional).

### Checklist

- [x] Code compiles
- [x] UI looks good on different screen sizes (N/A)
- [x] No warnings or errors
- [x] I’ve manually tested the changes
